### PR TITLE
Fix for the signature provider

### DIFF
--- a/src/nimSignature.ts
+++ b/src/nimSignature.ts
@@ -93,7 +93,7 @@ export class NimSignatureHelpProvider implements vscode.SignatureHelpProvider {
               signature.parameters.push(new vscode.ParameterInformation(parameter));
             });
 
-            if (item.names[0] == identBeforeDot)
+            if (item.names[0] == identBeforeDot || item.path.search("/" + identBeforeDot + "/") != -1 || item.path.search("\\\\" + identBeforeDot + "\\\\") != -1)
               isModule++;
 
             signatures.signatures.push(signature);

--- a/src/nimSignature.ts
+++ b/src/nimSignature.ts
@@ -63,8 +63,6 @@ export class NimSignatureHelpProvider implements vscode.SignatureHelpProvider {
           identBeforeDot = line.substring(start, dotPosition);
         }
       }
-      console.log(identBeforeDot + " " + currentArgument);
-
 
       execNimSuggest(NimSuggestType.con, filename, position.line + 1, position.character - 1, getDirtyFile(document))
         .then(items => {
@@ -76,7 +74,20 @@ export class NimSignatureHelpProvider implements vscode.SignatureHelpProvider {
           items.forEach(item => {
             var signature = new vscode.SignatureInformation(item.type, item.documentation);
 
-            var signatureCutDown = /(proc|macro|template) \((([\w.]+: [\w.,;\[\] ]+([,;] )?)*)\)/.exec(item.type);
+            var genericsCleanType = "";
+            {
+              var insideGeneric = 0;
+              for (var i = 0; i < item.type.length; i++) {
+                if (item.type[i] == "[")
+                  insideGeneric++;
+                if (!insideGeneric)
+                  genericsCleanType += item.type[i];
+                if (item.type[i] == "]")
+                  insideGeneric--;
+              }
+            }
+
+            var signatureCutDown = /(proc|macro|template) \((.+: .+)*\)/.exec(genericsCleanType);
             var parameters = signatureCutDown[2].split(", ");
             parameters.forEach(parameter => {
               signature.parameters.push(new vscode.ParameterInformation(parameter));


### PR DESCRIPTION
It solves an infinte loop which somehow occurs because of a regular expression which couldn't be resolved. Also I improved how it operates with generics(where the parameter suggestion sometimes got screwed up). And at last but not least it fixes that when calling a function from a sub package of an imported package it showed the wrong selected parameter.