### PR TITLE
Some small fixes

### DIFF
--- a/snippets/nim.json
+++ b/snippets/nim.json
@@ -30,11 +30,11 @@
         },
         "while": {
             "prefix": "while",
-            "body": "while ${1:expression}\n\t$0"
+            "body": "while ${1:expression}:\n\t$0"
         },
         "block": {
             "prefix": "block",
-            "body": "block ${1:name}\n\t$0"
+            "body": "block ${1:name}:\n\t$0"
         },
         "case": {
             "prefix": "case",

--- a/src/nimMain.ts
+++ b/src/nimMain.ts
@@ -54,6 +54,15 @@ export function activate(ctx: vscode.ExtensionContext): void {
                 afterText: /.+$/,
                 action: { indentAction: vscode.IndentAction.None, appendText: '## ' }
             }
+        ],
+        comments: {
+            lineComment: "#",
+            blockComment: ["#[", "]#"],
+        },
+        brackets: [
+            ["[", "]"],
+            ["(", ")"],
+            ["\"", "\""] // Not the best solution
         ]
     });
 

--- a/src/nimMain.ts
+++ b/src/nimMain.ts
@@ -56,13 +56,14 @@ export function activate(ctx: vscode.ExtensionContext): void {
             }
         ],
         comments: {
-            lineComment: "#",
-            blockComment: ["#[", "]#"],
+            lineComment: '#',
+            blockComment: ['#[', ']#'],
         },
         brackets: [
-            ["[", "]"],
-            ["(", ")"],
-            ["\"", "\""] // Not the best solution
+            ['[', ']'],
+            ['(', ')'],
+            ['"', '"'],
+            ['\'', '\'']
         ]
     });
 

--- a/src/nimSignature.ts
+++ b/src/nimSignature.ts
@@ -89,7 +89,7 @@ export class NimSignatureHelpProvider implements vscode.SignatureHelpProvider {
               }
             }
 
-            var signatureCutDown = /(proc|macro|template) \((.+: .+)*\)/.exec(genericsCleanType);
+            var signatureCutDown = /(proc|macro|template|iterator) \((.+: .+)*\)/.exec(genericsCleanType);
             var parameters = signatureCutDown[2].split(', ');
             parameters.forEach(parameter => {
               signature.parameters.push(new vscode.ParameterInformation(parameter));


### PR DESCRIPTION
* Fixed #35 
* Readded bracket auto closing(it is intended that the string literals are brackets, VSCode recognises this and doesn't show a box around quotation marks)
* Fixed signature completion of iterators
* Fixed two snippets which pasted invalid code