### PR TITLE
Allows compile/run files in a path with spaces

### DIFF
--- a/src/nimMain.ts
+++ b/src/nimMain.ts
@@ -188,18 +188,18 @@ function runFile() {
         terminal.show(true);
         if (editor.document.isUntitled) {
             terminal.sendText('nim ' + vscode.workspace.getConfiguration('nim')['buildCommand'] +
-                ' -r ' + getDirtyFile(editor.document), true);
+                ' -r "' + getDirtyFile(editor.document)+'"', true);
         } else {
             if (editor.document.isDirty) {
                 editor.document.save().then((success: boolean) => {
                     if (success) {
                         terminal.sendText('nim ' + vscode.workspace.getConfiguration('nim')['buildCommand'] +
-                            ' -r ' + editor.document.fileName, true);
+                            ' -r "' + editor.document.fileName+'"', true);
                     }
                 });
             } else {
                 terminal.sendText('nim ' + vscode.workspace.getConfiguration('nim')['buildCommand'] +
-                    ' -r ' + editor.document.fileName, true);
+                    ' -r "' + editor.document.fileName+'"', true);
             }
         }
     }


### PR DESCRIPTION
- These changes allow to run/compile **[F6]** a file that has a path with spaces.
- Tested under **Windows 10** and **Xubuntu 16.10**.

[nim-0.5.19.vsix.zip](https://github.com/pragmagic/vscode-nim/files/811453/nim-0.5.19.vsix.zip)

