### PR TITLE
Fixing 'nim' binary could not be found in PATH on OS X

### DIFF
--- a/src/nimUtils.ts
+++ b/src/nimUtils.ts
@@ -75,18 +75,17 @@ export function getBinPath(tool: string): string {
         _pathesCache[tool] = pathparts.map(dir => path.join(dir, correctBinname(tool))).filter(candidate => fs.existsSync(candidate))[0];
         if (process.platform !== 'win32') {
             try {
-                let buff;
+                let nimPath;
                 if (process.platform === 'darwin') {
-                    // dirty hack because the version of readlink that ships with osx doesn't support the -f flag
-                    // from https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac#4031502
-                    buff = cp.execFileSync('python', ['-c', 'import os,sys;print(os.path.realpath(sys.argv[1]))', _pathesCache[tool]]);
+                    nimPath = _pathesCache[tool].slice(0, _pathesCache[tool].length - 3) + cp.execFileSync('readlink', [_pathesCache[tool]]).toString().trim();
                 } else if (process.platform === 'linux') {
-                    buff = cp.execFileSync('readlink', ['-f', _pathesCache[tool]]);
+                    nimPath = cp.execFileSync('readlink', ['-f', _pathesCache[tool]]).toString().trim();
                 } else {
-                    buff = cp.execFileSync('readlink', [_pathesCache[tool]]);
+                    nimPath = cp.execFileSync('readlink', [_pathesCache[tool]]).toString().trim();
                 }
-                if (buff.length > 0) {
-                    _pathesCache[tool] = buff.toString().trim();
+
+                if (nimPath.length > 0) {
+                    _pathesCache[tool] = nimPath;
                 }
             } catch (e) {
                 // ignore exception

--- a/src/nimUtils.ts
+++ b/src/nimUtils.ts
@@ -74,9 +74,17 @@ export function getBinPath(tool: string): string {
         var pathparts = (<string>process.env.PATH).split((<any>path).delimiter);
         _pathesCache[tool] = pathparts.map(dir => path.join(dir, correctBinname(tool))).filter(candidate => fs.existsSync(candidate))[0];
         if (process.platform !== 'win32') {
-            let args = process.platform === 'linux' ? ['-f', _pathesCache[tool]] : [_pathesCache[tool]];
             try {
-                let buff = cp.execFileSync('readlink', args);
+                let buff;
+                if (process.platform === 'darwin') {
+                    // dirty hack because the version of readlink that ships with osx doesn't support the -f flag
+                    // from https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac#4031502
+                    buff = cp.execFileSync('python', ['-c', 'import os,sys;print(os.path.realpath(sys.argv[1]))', _pathesCache[tool]]);
+                } else if (process.platform === 'linux') {
+                    buff = cp.execFileSync('readlink', ['-f', _pathesCache[tool]]);
+                } else {
+                    buff = cp.execFileSync('readlink', [_pathesCache[tool]]);
+                }
                 if (buff.length > 0) {
                     _pathesCache[tool] = buff.toString().trim();
                 }


### PR DESCRIPTION
The output of ```readlink``` without the -f flag is a non absolute path. As a result, if you used brew to install nim, the correct binary can't be detected and the error message is shown.

See https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac#4031502 on the readlink problem and a solution.

My solution is a bit hacky but should work on all OS X versions.