### PR TITLE
[To be discussed]Casing conversion

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "bugs": {
         "url": "https://github.com/pragmagic/vscode-nim/issues"
-	},
+    },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
@@ -144,6 +144,66 @@
                     "type": "string",
                     "default": "",
                     "description": "Optional license text that will be inserted on nim file creation."
+                },
+                "nim.typeCasing": {
+                    "type": "string",
+                    "default": "as-is",
+                    "description": "The casing of types and type aliases",
+                    "enum": [
+                        "as-is",
+                        "pascal-camel",
+                        "snake"
+                    ]
+                },
+                "nim.moduleCasing": {
+                    "type": "string",
+                    "default": "as-is",
+                    "description": "The casing of modules",
+                    "enum": [
+                        "as-is",
+                        "pascal-camel",
+                        "snake"
+                    ]
+                },
+                "nim.procLikeCasing": {
+                    "type": "string",
+                    "default": "as-is",
+                    "description": "The casing of procs, templates, macros and iterators",
+                    "enum": [
+                        "as-is",
+                        "pascal-camel",
+                        "snake"
+                    ]
+                },
+                "nim.constantCasing": {
+                    "type": "string",
+                    "default": "as-is",
+                    "description": "The casing of constants",
+                    "enum": [
+                        "as-is",
+                        "pascal-camel",
+                        "snake"
+                    ]
+                },
+                "nim.enumFieldCasing": {
+                    "type": "string",
+                    "default": "as-is",
+                    "description": "The casing of enum fields",
+                    "enum": [
+                        "as-is",
+                        "pascal-camel",
+                        "snake"
+                    ]
+                },
+                "nim.variableCasing": {
+                    "type": "string",
+                    "default": "as-is",
+                    "description": "The casing of var, let, parameters, result and object/tuple fields",
+                    "enum": [
+                        "as-is",
+                        "pascal-camel",
+                        "snake"
+                    ]
                 }
             }
         },

--- a/src/nimBuild.ts
+++ b/src/nimBuild.ts
@@ -57,7 +57,14 @@ function nimExec(project: string, command: string, args: string[], useStdErr: bo
             } else {
                 executors[project] = null;
                 try {
-                    var ret = callback(out.split(os.EOL));
+                    let split = out.split(os.EOL);
+                    if (split.length == 1) {
+                        var lfSplit = split[0].split("\n");
+                        if(lfSplit.length > split.length)
+                            split = lfSplit;
+                    }
+
+                    var ret = callback(split);
                     resolve(ret);
                 } catch (e) {
                     reject(e);

--- a/src/nimBuild.ts
+++ b/src/nimBuild.ts
@@ -58,9 +58,9 @@ function nimExec(project: string, command: string, args: string[], useStdErr: bo
                 executors[project] = null;
                 try {
                     let split = out.split(os.EOL);
-                    if (split.length == 1) {
-                        var lfSplit = split[0].split("\n");
-                        if(lfSplit.length > split.length)
+                    if (split.length === 1) {
+                        var lfSplit = split[0].split('\n');
+                        if (lfSplit.length > split.length)
                             split = lfSplit;
                     }
 

--- a/src/nimCasing.ts
+++ b/src/nimCasing.ts
@@ -1,0 +1,106 @@
+/*---------------------------------------------------------
+ * Copyright (C) Xored Software Inc., RSDuck All rights reserved.
+ * Licensed under the MIT License. See LICENSE in the project root for license information.
+ *--------------------------------------------------------*/
+
+import vscode = require('vscode');
+
+function casingSplit(sym: string): [boolean, string[]] {
+    if (!sym.match(/\w+/)) return [false, [sym]]; // exclude operators
+    if (sym === sym.toUpperCase()) sym = sym.toLowerCase(); // for C_IDENTIFIERS_LIKE_SO
+    let start = 0;
+    let capital = sym[0].toUpperCase() === sym[0];
+    let result: string[] = [];
+    for (let i = 0; i < sym.length; i++) {
+        if (i > 0 && ((sym[i].toUpperCase() === sym[i] && sym[i] !== '_') || sym[i - 1] === '_')) {
+            let wasUnderscore = sym[i - 1] === '_' ? 1 : 0;
+            result.push(sym.substring(start, i - wasUnderscore).toLowerCase());
+            start = i;
+        }
+    }
+    result.push(sym.substring(start, sym.length).toLowerCase());
+    if (result[result.length - 1] === '=') {
+        result.pop();
+        result[result.length - 1] = result[result.length - 1] + '=';
+    }
+    return [capital, result];
+}
+
+function toCamelPascalCase(sym: string) {
+    let parts = casingSplit(sym);
+    if (parts[0]) {
+        let assembled = '';
+        for (let i = 0; i < parts[1].length; i++) {
+            assembled += parts[1][i][0].toUpperCase() + parts[1][i].substring(1, parts[1][i].length);
+        }
+        return assembled;
+    } else {
+        let assembled = parts[1][0];
+        for (let i = 1; i < parts[1].length; i++)
+            assembled += parts[1][i][0].toUpperCase() + parts[1][i].substring(1, parts[1][i].length);
+        return assembled;
+    }
+}
+
+function toSnakeCase(sym: string): string {
+    let parts = casingSplit(sym);
+    if (parts[0]) {
+        let assembled = parts[1][0][0].toUpperCase() + parts[1][0].substring(1, parts[1][0].length);
+        for (let i = 1; i < parts[1].length; i++)
+            assembled += '_' + parts[1][i][0].toUpperCase() + parts[1][i].substring(1, parts[1][i].length);
+        return assembled;
+    } else {
+        let assembled = parts[1][0];
+        for (let i = 1; i < parts[1].length; i++) {
+            assembled += '_' + parts[1][i];
+        }
+        return assembled;
+    }
+}
+
+function keepCasing(sym: string): string { return sym; }
+
+let
+    nimCasingConfig = new Map<string, (sym: string) => string>();
+
+export function configureCasing(config: vscode.WorkspaceConfiguration) {
+    function toFunction(mode: string): (sym: string) => string {
+        switch (mode) {
+            case 'as-is':
+                return keepCasing;
+            case 'pascal-camel':
+                return toCamelPascalCase;
+            case 'snake':
+                return toSnakeCase;
+        }
+    }
+
+    let typeCasing = toFunction(config['typeCasing']);
+    let moduleCasing = toFunction(config['moduleCasing']);
+    let procLikeCasing = toFunction(config['procLikeCasing']);
+    let constantCasing = toFunction(config['constantCasing']);
+    let enumFieldCasing = toFunction(config['enumFieldCasing']);
+    let variableCasing = toFunction(config['variableCasing']);
+
+    nimCasingConfig['skConst'] = constantCasing;
+    nimCasingConfig['skEnumField'] = enumFieldCasing;
+    nimCasingConfig['skForVar'] = variableCasing;
+    nimCasingConfig['skIterator'] = procLikeCasing;
+    nimCasingConfig['skLabel'] = variableCasing;
+    nimCasingConfig['skLet'] = variableCasing;
+    nimCasingConfig['skMacro'] = procLikeCasing;
+    nimCasingConfig['skMethod'] = procLikeCasing;
+    nimCasingConfig['skParam'] = variableCasing;
+    nimCasingConfig['skProc'] = procLikeCasing;
+    nimCasingConfig['skResult'] = variableCasing;
+    nimCasingConfig['skTemplate'] = procLikeCasing;
+    nimCasingConfig['skType'] = typeCasing;
+    nimCasingConfig['skVar'] = variableCasing;
+    nimCasingConfig['skField'] = variableCasing;
+    nimCasingConfig['skAlias'] = typeCasing;
+    nimCasingConfig['skModule'] = moduleCasing;
+}
+
+export function getCasingConfig(): Map<string, (sym: string) => string> {
+    return nimCasingConfig;
+}

--- a/src/nimUtils.ts
+++ b/src/nimUtils.ts
@@ -11,6 +11,7 @@ import os = require('os');
 import cp = require('child_process');
 import vscode = require('vscode');
 import { showNimStatus, hideNimStatus } from './nimStatus';
+import { configureCasing } from './nimCasing';
 
 let _pathesCache: { [tool: string]: string; } = {};
 var _projects: string[] = [];
@@ -66,6 +67,7 @@ export function prepareConfig(): void {
             _projects.push(path.isAbsolute(projects) ? projects : path.resolve(vscode.workspace.rootPath, projects));
         }
     }
+    configureCasing(config);
 }
 
 export function getBinPath(tool: string): string {


### PR DESCRIPTION
As stated [here](https://nim-lang.org/docs/manual.html#lexical-analysis-identifier-equality) it was originally envisioned that Nim users can configure there IDE so that it shows them identifiers in the way they like(Pascal/Camel, Snake case, …).

Yesterday I made this rough POC, which more or less works. E.g. if I prefer Snake-casing for function names, I could tweak `nim.typeCasing` to `snake`. vscode-nim will automatically suggest procs, templates, macros and iterators in snake case.
![a suggest result with everything in snake case](https://user-images.githubusercontent.com/9352526/36074258-ea9b96ac-0f3d-11e8-97e3-df8c3d1af5ae.png)
![a hover result in snake case](https://user-images.githubusercontent.com/9352526/36074270-19502a9e-0f3e-11e8-88d9-718489f0a864.png)

The implementation is still a bit rough, e.g. if you hover a call, the types in the proc signature aren't converted.

Some questions which arrive are:
- Is this even a responsibility of vscode-nim, nimsuggest should handle this?
- Should the configuration be more precise(more options)?