### PR TITLE
add support for globs in nim.project setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following Visual Studio Code settings are available for the Nim extension.  
 	}
 	```
 * `nim.lintOnSave` - perform the project check for errors on save
-* `nim.project` - optional array of projects file, if nim.project is not defined then all nim files will be used as separate project
+* `nim.project` - optional array of projects file/glob paths, if nim.project is not defined then all nim files will be used as separate project
 * `nim.licenseString` - optional license text that will be inserted on nim file creation
 
 
@@ -58,7 +58,7 @@ The following Visual Studio Code settings are available for the Nim extension.  
 	"nim.buildOnSave": false,
 	"nim.buildCommand": "c",
 	"nim.lintOnSave": true,
-	"nim.project": ["project.nim", "project2.nim"],
+	"nim.project": ["project.nim", "project2.nim", "src/**/*.nim"],
 	"nim.licenseString": "# Copyright 2017.\n\n"
 }
 ```

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     },
     "bugs": {
         "url": "https://github.com/pragmagic/vscode-nim/issues"
-	},
+    },
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
@@ -32,7 +32,8 @@
         "lint": "node ./node_modules/tslint/bin/tslint ./src/*.ts ./test/*.ts"
     },
     "dependencies": {
-        "nedb": "1.8.0"
+        "nedb": "1.8.0",
+        "glob": "^7.1.2"
     },
     "devDependencies": {
         "typescript": "^2.0.3",
@@ -40,7 +41,8 @@
         "mocha": "^2.3.3",
         "tslint": "^4.3.1",
         "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
+        "@types/mocha": "^2.2.32",
+        "@types/glob": "^5.0.35"
     },
     "engines": {
         "vscode": "^1.7.0"


### PR DESCRIPTION
Instead of listing out all project files in vscode settings, this lets you specify glob patterns to match multiple files.

```json
{
  "nim.project": ["src/**/*.nim"]
}
```