### PR TITLE
add support to "nim check" for Threads and Channels

### DIFF
--- a/src/nimBuild.ts
+++ b/src/nimBuild.ts
@@ -149,10 +149,10 @@ export function check(filename: string, nimConfig: vscode.WorkspaceConfiguration
     } else {
         if (!isProjectMode()) {
             let project = getProjectFileInfo(filename);
-            runningToolsPromises.push(nimExec(project, 'check', ['--listFullPaths', project.filePath], true, parseErrors));
+            runningToolsPromises.push(nimExec(project, 'check', ['--threads:on', '--listFullPaths', project.filePath], true, parseErrors));
         } else {
             getProjects().forEach(project => {
-                runningToolsPromises.push(nimExec(project, 'check', ['--listFullPaths', project.filePath], true, parseErrors));
+                runningToolsPromises.push(nimExec(project, 'check', ['--threads:on', '--listFullPaths', project.filePath], true, parseErrors));
             });
         }
     }


### PR DESCRIPTION
test with the following code snippet:
```nim
import os, threadpool

var chan: Channel[string]
open (chan)
 
proc sayHello () =
  chan.send("Hello" )

spawn sayHello()
echo chan.recv()
```
You get the following errors without this small patch:

![image](https://user-images.githubusercontent.com/2781333/49697474-9c2c7880-fb6c-11e8-865d-a48bae5f6494.png)

when the patch is applied, the checker understands the threadpool classes:

![image](https://user-images.githubusercontent.com/2781333/49697487-d269f800-fb6c-11e8-87e5-e6c6d2903aaf.png)

The patch is simple and adds `--threads:on` to the check command.  Since threads:on was introduced over 4 years ago and it's not harmful to leave it on the command line even when not using threads, I would consider this a safe fix. 

However, an improvement would be to use a workspace configuration variable (maybe something like nim.checkFlags` ) for supplying additional flags to the check command. 

