### PR TITLE
Fix nimsuggest on paths with Unicode characters

### DIFF
--- a/src/elrpc/elrpc.ts
+++ b/src/elrpc/elrpc.ts
@@ -3,10 +3,11 @@
  * Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------*/
 import net = require('net');
+import util = require('util');
 import sexp = require('./sexp');
 
 function envelope(content: string): string {
-    return ('000000' + content.length.toString(16)).slice(-6) + content;
+    return ('000000' + (new util.TextEncoder().encode(content).length).toString(16)).slice(-6) + content;
 }
 
 function generateUID(): number {


### PR DESCRIPTION
Current envelope length caused a crash when directory contained Unicode characters (which weighted more than 1 byte), because nimsuggest expects size in bytes, not characters.