### PR TITLE
Block string literals

### DIFF
--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1237,8 +1237,8 @@
     },
     "string_block_init-tag": {
       "name": "string.quoted.block.init-tag.nim",
-      "begin": "(\\w*)(\")(:)",
-      "end": "\\G\\s*$",
+      "begin": "(\\w*)(\")(:)(?=\\s*$)",
+      "end": "$",
       "beginCaptures": {
         "1": {
           "name": "support.function.any-method.nim"

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1015,6 +1015,43 @@
     }
   ],
   "repository": {
+		"blockstrings": {
+			"patterns": [
+				{ "include": "#block-container_string-raw" },
+				{ "include": "#block-container_string" }
+			]
+		},
+		"block-container_string-raw": {
+			"name": "meta.structure.block-container.string-raw.nim",
+			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\.|[^\"])*\")*)(r\":)$)",
+			"while": "^(?:\\1  |\\s*$)",
+			"patterns": [
+				{ "include": "#block-initial-line" },
+				{
+					"match": "(?:[^\\s]|\\s(?!\\s*$))+",
+					"name": "string.quoted.block.raw.nim"
+				}
+			]
+		},
+		"block-container_string": {
+			"name": "meta.structure.block-container.string.nim",
+			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\.|[^\"])*\")*)(\":)$)",
+			"while": "^(?:\\1  |\\s*$)",
+			"patterns": [
+				{ "include": "#block-container_initial-line" },
+				{ "include": "#string_escapes" },
+				{
+					"match": "(?:[^\\s\\\\]|\\s(?!\\s*$))+",
+					"name": "string.quoted.block.nim"
+				}
+			]
+		},
+		"block-container_initial-line": {
+			"begin": "^",
+			"end": "$",
+			"name": "meta.structure.block-container.initial-line.nim",
+			"patterns": [{ "include": "#expressions" }]
+		},
     "multilinecomment": {
       "begin": "#\\[",
       "end": "\\]#",
@@ -1086,11 +1123,19 @@
         {
           "match": "\\\\\\\\",
           "name": "constant.character.escape.backslash.nim"
+        },
+        {
+          "match": "\\\\.",
+          "name": "invalid.illegal.unknown-escape.nim"
         }
       ]
     },
     "string_escapes": {
       "patterns": [
+        {
+          "match": "\\\\$",
+          "name": "constant.character.escape.no-newline.nim"
+        },
         {
           "match": "\\\\[pP]",
           "name": "constant.character.escape.newline.nim"

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -203,7 +203,7 @@
               "meta": "punctuation.definition.string.begin.nim"
             }
           },
-          "end": "\"",
+          "end": "\"|$",
           "endCaptures": {
             "0": "punctuation.definition.string.end.nim"
           },
@@ -1261,7 +1261,7 @@
           "name": "punctuation.definition.string.begin.nim"
         }
       },
-      "end": "\"",
+      "end": "\"|$",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.end.nim"
@@ -1314,7 +1314,7 @@
           "name": "punctuation.definition.string.begin.nim"
         }
       },
-      "end": "\"",
+      "end": "\"|$",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.end.nim"
@@ -1403,7 +1403,7 @@
         }
       },
       "comment": "Double Quoted String",
-      "end": "\"",
+      "end": "\"|$",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.end.nim"
@@ -1423,7 +1423,7 @@
           "name": "punctuation.definition.string.begin.nim"
         }
       },
-      "end": "\"",
+      "end": "\"|$",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.end.nim"
@@ -1446,7 +1446,7 @@
           "name": "punctuation.definition.string.begin.nim"
         }
       },
-      "end": "\"",
+      "end": "\"|$",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.end.nim"
@@ -1467,7 +1467,7 @@
         }
       },
       "comment": "Single quoted character literal",
-      "end": "'",
+      "end": "'|$",
       "endCaptures": {
         "0": {
           "name": "punctuation.definition.string.end.nim"

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1241,7 +1241,7 @@
       "end": "\\G\\s*$",
       "beginCaptures": {
         "1": {
-          "name": "storage.type.string.nim"
+          "name": "support.function.any-method.nim"
         },
         "2": {
           "name": "punctuation.definition.string.begin.nim"

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1029,7 +1029,7 @@
 		},
 		"block-container_string-raw": {
 			"name": "meta.structure.block-container.string-raw.nim",
-			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\\w+\":)$)",
+			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\\w+\":)$)(?!.*\"\"\")",
 			"while": "^(?:\\1  |\\s*$)",
 			"patterns": [
 				{ "include": "#block-container_initial-line" },
@@ -1041,7 +1041,7 @@
 		},
 		"block-container_string": {
 			"name": "meta.structure.block-container.string.nim",
-			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\":)$)",
+			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\":)$)(?!.*\"\"\")",
 			"while": "^(?:\\1  |\\s*$)",
 			"patterns": [
 				{ "include": "#block-container_initial-line" },

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1029,10 +1029,10 @@
 		},
 		"block-container_string-raw": {
 			"name": "meta.structure.block-container.string-raw.nim",
-			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\.|[^\"])*\")*)(r\":)$)",
+			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(r\":)$)",
 			"while": "^(?:\\1  |\\s*$)",
 			"patterns": [
-				{ "include": "#block-initial-line" },
+				{ "include": "#block-container_initial-line" },
 				{
 					"match": "(?:[^\\s]|\\s(?!\\s*$))+",
 					"name": "string.quoted.block.raw.nim"
@@ -1041,7 +1041,7 @@
 		},
 		"block-container_string": {
 			"name": "meta.structure.block-container.string.nim",
-			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\.|[^\"])*\")*)(\":)$)",
+			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\":)$)",
 			"while": "^(?:\\1  |\\s*$)",
 			"patterns": [
 				{ "include": "#block-container_initial-line" },
@@ -1195,6 +1195,9 @@
     "string_literal": {
       "patterns": [
         {
+          "include": "#string_block_init-tag"
+        },
+        {
           "include": "#fmt_string_triple"
         },
         {
@@ -1231,6 +1234,22 @@
           "include": "#string_quoted_double"
         }
       ]
+    },
+    "string_block_init-tag": {
+      "name": "string.quoted.block.init-tag.nim",
+      "begin": "(\\w*)(\")(:)",
+      "end": "\\G\\s*$",
+      "beginCaptures": {
+        "1": {
+          "name": "storage.type.string.nim"
+        },
+        "2": {
+          "name": "punctuation.definition.string.begin.nim"
+        },
+        "3": {
+          "name": "keyword.operator.nim"
+        }
+      }
     },
     "fmt_string": {
       "begin": "\\b(fmt)(\")",

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -5,6 +5,7 @@
   "keyEquivalent": "^~N",
   "name": "Nim",
   "patterns": [
+    { "include": "#blockstrings" },
     {
       "begin": "[ \\t]*##\\[",
       "contentName": "comment.block.doc-comment.content.nim",
@@ -72,137 +73,12 @@
       ]
     },
     {
-      "comment": "A nim procedure or method",
-      "name": "meta.proc.nim",
-      "patterns": [
-        {
-          "begin": "\\b(proc|method|template|macro|iterator|converter|func)\\s+\\`?([^\\:\\{\\s\\`\\*\\(]*)\\`?(\\s*\\*)?\\s*(?=\\(|\\=|:|\\[|\\n|\\{)",
-          "captures": {
-            "1": {
-              "name": "keyword.other"
-            },
-            "2": {
-              "name": "entity.name.function.nim"
-            },
-            "3": {
-              "name": "keyword.control.export"
-            }
-          },
-          "end": "\\)",
-          "patterns": [
-            {
-              "include": "source.nim"
-            }
-          ]
-        }
-      ]
-    },
-    {
       "begin": "discard \"\"\"",
       "comment": "A discarded triple string literal comment",
       "end": "\"\"\"(?!\")",
       "name": "comment.line.discarded.nim"
     },
-    {
-      "include": "#float_literal"
-    },
-    {
-      "include": "#integer_literal"
-    },
-    {
-      "comment": "Operator as function name",
-      "match": "(?<=\\`)[^\\` ]+(?=\\`)",
-      "name": "entity.name.function.nim"
-    },
-    {
-      "captures": {
-        "1": {
-          "name": "keyword.control.export"
-        }
-      },
-      "comment": "Export qualifier.",
-      "match": "\\b\\s*(\\*)(?:\\s*(?=[,:])|\\s+(?=[=]))"
-    },
-    {
-      "comment": "Export qualifier following a type def.",
-      "match": "\\b([A-Z]\\w+)(\\*)",
-      "captures": {
-        "1": {
-          "name": "support.type.nim"
-        },
-        "2": {
-          "name": "keyword.control.export"
-        }
-      }
-    },
-    {
-      "include": "#string_literal"
-    },
-    {
-      "comment": "Language Constants.",
-      "match": "\\b(true|false|Inf|NegInf|NaN|nil)\\b",
-      "name": "constant.language.nim"
-    },
-    {
-      "comment": "Keywords that affect program control flow or scope.",
-      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|raise|return|try|when|while|yield)\\b",
-      "name": "keyword.control.nim"
-    },
-    {
-      "comment": "Keyword boolean operators for expressions.",
-      "match": "(\\b(and|in|is|isnot|not|notin|or|xor)\\b)",
-      "name": "keyword.boolean.nim"
-    },
-    {
-      "comment": "Generic operators for expressions.",
-      "match": "(=|\\+|-|\\*|/|<|>|@|\\$|~|&|%|!|\\?|\\^|\\.|:|\\\\)+",
-      "name": "keyword.operator.nim"
-    },
-    {
-      "comment": "Other keywords.",
-      "match": "(\\b(addr|as|asm|atomic|bind|cast|const|converter|concept|defer|discard|distinct|div|enum|export|from|import|include|let|mod|mixin|object|of|ptr|ref|shl|shr|static|type|using|var|tuple|iterator|macro|func|method|proc|template)\\b)",
-      "name": "keyword.other.nim"
-    },
-    {
-      "comment": "Invalid and unused keywords.",
-      "match": "(\\b(generic|interface|lambda|out|shared)\\b)",
-      "name": "invalid.illegal.invalid-keyword.nim"
-    },
-    {
-      "comment": "Common functions",
-      "match": "\\b(new|await|assert|echo|defined|declared|newException|countup|countdown|high|low)\\b",
-      "name": "keyword.other.common.function.nim"
-    },
-    {
-      "comment": "Built-in, concrete types.",
-      "match": "\\b(((uint|int)(8|16|32|64)?)|float(32|64)?|bool|string|auto|cstring|char|byte|tobject|typedesc|stmt|expr|any|untyped|typed)\\b",
-      "name": "storage.type.concrete.nim"
-    },
-    {
-      "comment": "Built-in, generic types.",
-      "match": "\\b(range|array|seq|set|pointer)\\b",
-      "name": "storage.type.generic.nim"
-    },
-    {
-      "comment": "Special types.",
-      "match": "\\b(openarray|varargs|void)\\b",
-      "name": "storage.type.generic.nim"
-    },
-    {
-      "comment": "Other constants.",
-      "match": "\\b[A-Z][A-Z0-9_]+\\b",
-      "name": "support.constant.nim"
-    },
-    {
-      "comment": "Other types.",
-      "match": "\\b[A-Z]\\w+\\b",
-      "name": "support.type.nim"
-    },
-    {
-      "comment": "Function call.",
-      "match": "\\b\\w+\\b(?=\\()",
-      "name": "support.function.any-method.nim"
-    },
+    { "include": "#expressions" },
     {
       "begin": "(^\\s*)?(?=\\{\\.emit: ?\"\"\")",
       "beginCaptures": {
@@ -1015,6 +891,136 @@
     }
   ],
   "repository": {
+    "expressions": {
+      "patterns": [
+        {
+          "comment": "A nim procedure or method",
+          "name": "meta.proc.nim",
+          "patterns": [
+            {
+              "begin": "\\b(proc|method|template|macro|iterator|converter|func)\\s+\\`?([^\\:\\{\\s\\`\\*\\(]*)\\`?(\\s*\\*)?\\s*(?=\\(|\\=|:|\\[|\\n|\\{)",
+              "captures": {
+                "1": {
+                  "name": "keyword.other"
+                },
+                "2": {
+                  "name": "entity.name.function.nim"
+                },
+                "3": {
+                  "name": "keyword.control.export"
+                }
+              },
+              "end": "\\)",
+              "patterns": [
+                {
+                  "include": "source.nim"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "include": "#float_literal"
+        },
+        {
+          "include": "#integer_literal"
+        },
+        {
+          "comment": "Operator as function name",
+          "match": "(?<=\\`)[^\\` ]+(?=\\`)",
+          "name": "entity.name.function.nim"
+        },
+        {
+          "captures": {
+            "1": {
+              "name": "keyword.control.export"
+            }
+          },
+          "comment": "Export qualifier.",
+          "match": "\\b\\s*(\\*)(?:\\s*(?=[,:])|\\s+(?=[=]))"
+        },
+        {
+          "comment": "Export qualifier following a type def.",
+          "match": "\\b([A-Z]\\w+)(\\*)",
+          "captures": {
+            "1": {
+              "name": "support.type.nim"
+            },
+            "2": {
+              "name": "keyword.control.export"
+            }
+          }
+        },
+        {
+          "include": "#string_literal"
+        },
+        {
+          "comment": "Language Constants.",
+          "match": "\\b(true|false|Inf|NegInf|NaN|nil)\\b",
+          "name": "constant.language.nim"
+        },
+        {
+          "comment": "Keywords that affect program control flow or scope.",
+          "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|raise|return|try|when|while|yield)\\b",
+          "name": "keyword.control.nim"
+        },
+        {
+          "comment": "Keyword boolean operators for expressions.",
+          "match": "(\\b(and|in|is|isnot|not|notin|or|xor)\\b)",
+          "name": "keyword.boolean.nim"
+        },
+        {
+          "comment": "Generic operators for expressions.",
+          "match": "(=|\\+|-|\\*|/|<|>|@|\\$|~|&|%|!|\\?|\\^|\\.|:|\\\\)+",
+          "name": "keyword.operator.nim"
+        },
+        {
+          "comment": "Other keywords.",
+          "match": "(\\b(addr|as|asm|atomic|bind|cast|const|converter|concept|defer|discard|distinct|div|enum|export|from|import|include|let|mod|mixin|object|of|ptr|ref|shl|shr|static|type|using|var|tuple|iterator|macro|func|method|proc|template)\\b)",
+          "name": "keyword.other.nim"
+        },
+        {
+          "comment": "Invalid and unused keywords.",
+          "match": "(\\b(generic|interface|lambda|out|shared)\\b)",
+          "name": "invalid.illegal.invalid-keyword.nim"
+        },
+        {
+          "comment": "Common functions",
+          "match": "\\b(new|await|assert|echo|defined|declared|newException|countup|countdown|high|low)\\b",
+          "name": "keyword.other.common.function.nim"
+        },
+        {
+          "comment": "Built-in, concrete types.",
+          "match": "\\b(((uint|int)(8|16|32|64)?)|float(32|64)?|bool|string|auto|cstring|char|byte|tobject|typedesc|stmt|expr|any|untyped|typed)\\b",
+          "name": "storage.type.concrete.nim"
+        },
+        {
+          "comment": "Built-in, generic types.",
+          "match": "\\b(range|array|seq|set|pointer)\\b",
+          "name": "storage.type.generic.nim"
+        },
+        {
+          "comment": "Special types.",
+          "match": "\\b(openarray|varargs|void)\\b",
+          "name": "storage.type.generic.nim"
+        },
+        {
+          "comment": "Other constants.",
+          "match": "\\b[A-Z][A-Z0-9_]+\\b",
+          "name": "support.constant.nim"
+        },
+        {
+          "comment": "Other types.",
+          "match": "\\b[A-Z]\\w+\\b",
+          "name": "support.type.nim"
+        },
+        {
+          "comment": "Function call.",
+          "match": "\\b\\w+\\b(?=\\()",
+          "name": "support.function.any-method.nim"
+        }
+      ]
+    },
 		"blockstrings": {
 			"patterns": [
 				{ "include": "#block-container_string-raw" },

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1029,7 +1029,7 @@
 		},
 		"block-container_string-raw": {
 			"name": "meta.structure.block-container.string-raw.nim",
-			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(r\":)$)",
+			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\\w+\":)$)",
 			"while": "^(?:\\1  |\\s*$)",
 			"patterns": [
 				{ "include": "#block-container_initial-line" },

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1029,7 +1029,7 @@
 		},
 		"block-container_string-raw": {
 			"name": "meta.structure.block-container.string-raw.nim",
-			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\\w+\":)$)(?!.*\"\"\")",
+			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\\w+\":)\\s*$)(?!.*\"\"\")",
 			"while": "^(?:\\1  |\\s*$)",
 			"patterns": [
 				{ "include": "#block-container_initial-line" },
@@ -1041,7 +1041,7 @@
 		},
 		"block-container_string": {
 			"name": "meta.structure.block-container.string.nim",
-			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\":)$)(?!.*\"\"\")",
+			"begin": "(?=^( *)((?:[^#\"]|\"(?:\\\\.|[^\"])*\")*)(\":)\\s*$)(?!.*\"\"\")",
 			"while": "^(?:\\1  |\\s*$)",
 			"patterns": [
 				{ "include": "#block-container_initial-line" },


### PR DESCRIPTION
Fixed a bug with `":"` being detected as block string init tag, and additionally made end-of-line whitespace handling consistent. I couldn't find a problem with single quotes, which are not used in string blocks anyway.
