### PR TITLE
Rename provider

### DIFF
--- a/src/nimMain.ts
+++ b/src/nimMain.ts
@@ -14,6 +14,7 @@ import { NimCompletionItemProvider } from './nimSuggest';
 import { NimDefinitionProvider } from './nimDeclaration';
 import { NimReferenceProvider } from './nimReferences';
 import { NimHoverProvider } from './nimHover';
+import { NimRenameProvider } from './nimRename';
 import { NimDocumentSymbolProvider, NimWorkspaceSymbolProvider } from './nimOutline';
 import * as indexer from './nimIndexer';
 import { NimSignatureHelpProvider } from './nimSignature';
@@ -40,6 +41,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
     ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(NIM_MODE, new NimCompletionItemProvider(), '.', ' '));
     ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(NIM_MODE, new NimDefinitionProvider()));
     ctx.subscriptions.push(vscode.languages.registerReferenceProvider(NIM_MODE, new NimReferenceProvider()));
+    ctx.subscriptions.push(vscode.languages.registerRenameProvider(NIM_MODE, new NimRenameProvider()));
     ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(NIM_MODE, new NimDocumentSymbolProvider()));
     ctx.subscriptions.push(vscode.languages.registerSignatureHelpProvider(NIM_MODE, new NimSignatureHelpProvider(), '(', ','));
     ctx.subscriptions.push(vscode.languages.registerHoverProvider(NIM_MODE, new NimHoverProvider()));

--- a/src/nimMain.ts
+++ b/src/nimMain.ts
@@ -42,7 +42,7 @@ export function activate(ctx: vscode.ExtensionContext): void {
         ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(NIM_MODE, new NimCompletionItemProvider(), '.', ' '));
         ctx.subscriptions.push(vscode.languages.registerDefinitionProvider(NIM_MODE, new NimDefinitionProvider()));
         ctx.subscriptions.push(vscode.languages.registerReferenceProvider(NIM_MODE, new NimReferenceProvider()));
-        ctx.subscriptions.push(vscode.languages.registerRenameProvider(NIM_MODE, new NimRenameProvider()));  
+        ctx.subscriptions.push(vscode.languages.registerRenameProvider(NIM_MODE, new NimRenameProvider()));
         ctx.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(NIM_MODE, new NimDocumentSymbolProvider()));
         ctx.subscriptions.push(vscode.languages.registerSignatureHelpProvider(NIM_MODE, new NimSignatureHelpProvider(), '(', ','));
         ctx.subscriptions.push(vscode.languages.registerHoverProvider(NIM_MODE, new NimHoverProvider()));

--- a/src/nimRename.ts
+++ b/src/nimRename.ts
@@ -1,0 +1,29 @@
+'use strict';
+
+import vscode = require('vscode');
+import { getDirtyFile } from './nimUtils';
+import { execNimSuggest, NimSuggestType } from './nimSuggestExec';
+
+export class NimRenameProvider implements vscode.RenameProvider {
+
+  public provideRenameEdits(document: vscode.TextDocument, position: vscode.Position, newName: string, token: vscode.CancellationToken): Thenable<vscode.WorkspaceEdit> {
+    return new Promise<vscode.WorkspaceEdit>((resolve, reject) => {
+      vscode.workspace.saveAll(false).then(() => {
+          execNimSuggest(NimSuggestType.use, document.fileName, position.line + 1, position.character, getDirtyFile(document))
+            .then(result => {
+              var references: vscode.WorkspaceEdit = new vscode.WorkspaceEdit();
+              if (result) {
+                result.forEach(item => {
+                  let endPosition = new vscode.Position(item.range.end.line, item.range.end.character + item.symbolName.length);
+                  references.replace(item.uri, new vscode.Range(item.range.start, endPosition), newName);
+                });
+                resolve(references);
+              } else {
+                resolve();
+              }
+            })
+            .catch(reason => reject(reason));
+        });
+    });
+  }
+}


### PR DESCRIPTION
Adds a rename provider, which allows for IDE-like rename refactoring.  

This does not work well currently (nim v1.0.4) because of a bug in `nimsuggest`: it fails to find the symbol inside `template`.  However, this is fixed in the next nim release.  

See: https://github.com/nim-lang/Nim/commit/ff5ef95414e48714efd0ce2b3b694de1017032dc

It's possible `nimsuggest` could fail to find symbols in other situations, but the best way to get it up to scratch is to start using it, find it's problems, and fix them.