### PR TITLE
Fix incorrect position of symbol hover info

### DIFF
--- a/src/nimHover.ts
+++ b/src/nimHover.ts
@@ -25,9 +25,9 @@ export class NimHoverProvider implements vscode.HoverProvider {
               label += ': ' + def.type;
             let hoverLabel = { language: NIM_MODE.language as string, value: label };
             if (def.documentation !== '') {
-              resolve(new vscode.Hover([hoverLabel, def.documentation], def.range));
+              resolve(new vscode.Hover([hoverLabel, def.documentation]));
             } else {
-              resolve(new vscode.Hover(hoverLabel, def.range));
+              resolve(new vscode.Hover(hoverLabel));
             }
           } else {
             resolve();


### PR DESCRIPTION
Nimsuggest returns the position where the symbol is defined, so when you hover on a symbol it gets shown at the position of the definition if it's in the same file, or in a seemingly random position if it's defined in another file.