### PR TITLE
Fix passing arguments to nimpretty

### DIFF
--- a/src/nimFormatting.ts
+++ b/src/nimFormatting.ts
@@ -20,7 +20,7 @@ export class NimFormattingProvider implements vscode.DocumentFormattingEditProvi
       } else {
         let file = getDirtyFile(document);
         let config = vscode.workspace.getConfiguration('nim');
-        let res = cp.spawnSync(getNimPrettyExecPath(), ['--backup:OFF --indent:' + config['nimprettyIndent'] + ' --maxLineLen:' + config['nimprettyMaxLineLen'], file], { cwd: vscode.workspace.rootPath });
+        let res = cp.spawnSync(getNimPrettyExecPath(), ['--backup:OFF', '--indent:' + config['nimprettyIndent'], '--maxLineLen:' + config['nimprettyMaxLineLen'], file], { cwd: vscode.workspace.rootPath });
 
         if (res.status !== 0) {
           reject(res.error);


### PR DESCRIPTION
Fixed passing arguments to nimpretty.

The `Format Document` command of VSCode does not work when open a Nim file, because wrong arguments are passed to nimpretty.

