### PR TITLE
fix a few small mistakes in the nim textmate grammar

### DIFF
--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -313,12 +313,14 @@
               "name": "meta.preprocessor.pragma.nim"
             },
             "2": {
-              "meta": "punctuation.definition.string.begin.nim"
+              "name": "punctuation.definition.string.begin.nim"
             }
           },
           "end": "\"\"\"(?!\")",
           "endCaptures": {
-            "0": "punctuation.definition.string.end.nim"
+            "0": {
+              "name": "punctuation.definition.string.end.nim"
+            }
           },
           "name": "string.quoted.triple.raw.nim"
         },
@@ -329,12 +331,14 @@
               "name": "meta.preprocessor.pragma.nim"
             },
             "2": {
-              "meta": "punctuation.definition.string.begin.nim"
+              "name": "punctuation.definition.string.begin.nim"
             }
           },
           "end": "\"",
           "endCaptures": {
-            "0": "punctuation.definition.string.end.nim"
+            "0": {
+              "name": "punctuation.definition.string.end.nim"
+            }
           },
           "name": "string.quoted.double.raw.nim"
         },


### PR DESCRIPTION
this was crashing my editor implementation:

```console
$ babi test.nim
...
  File "/home/asottile/workspace/babi-grammars/venv/lib/python3.6/site-packages/babi/highlight.py", line 132, in make
    for k, v in dct['endCaptures'].items()
  File "/home/asottile/workspace/babi-grammars/venv/lib/python3.6/site-packages/babi/highlight.py", line 132, in <genexpr>
    for k, v in dct['endCaptures'].items()
  File "/home/asottile/workspace/babi-grammars/venv/lib/python3.6/site-packages/babi/highlight.py", line 106, in make
    name = _split_name(dct.get('name'))
AttributeError: 'str' object has no attribute 'get'
```