### PR TITLE
Fix issue related to Nim formatting. Args need to be splitted.

### DIFF
--- a/src/nimFormatting.ts
+++ b/src/nimFormatting.ts
@@ -20,7 +20,7 @@ export class NimFormattingProvider implements vscode.DocumentFormattingEditProvi
       } else {
         let file = getDirtyFile(document);
         let config = vscode.workspace.getConfiguration('nim');
-        let res = cp.spawnSync(getNimPrettyExecPath(), ['--backup:OFF --indent:' + config['nimprettyIndent'] + ' --maxLineLen:' + config['nimprettyMaxLineLen'], file], { cwd: vscode.workspace.rootPath });
+        let res = cp.spawnSync(getNimPrettyExecPath(), ['--backup:OFF', '--indent:' + config['nimprettyIndent'], '--maxLineLen:' + config['nimprettyMaxLineLen'], file], { cwd: vscode.workspace.rootPath });
 
         if (res.status !== 0) {
           reject(res.error);


### PR DESCRIPTION
The arguments provided to `spawnSync` should be splitted in different strings. Otherwise, nimpretty will receive everything as a single argument, and fails to interpret `OFF --indent:2 --maxLineLen:80 ...` as a boolean.

The issue happened to me in the following environment:
- Latest VSCode stable
- Latest version of the extension (0.6.6)
- Pop_OS 19.10

This change should fix it.