### PR TITLE
Support for `inim`. Maintain indentation of code blocks when sending code blocks to terminal

### DIFF
--- a/src/nimSuggestExec.ts
+++ b/src/nimSuggestExec.ts
@@ -10,7 +10,7 @@ import cp = require('child_process');
 import path = require('path');
 import fs = require('fs');
 import elrpc = require('./elrpc/elrpc');
-import { prepareConfig, getProjectFileInfo, isProjectMode, getNimExecPath, correctBinname, ProjectFileInfo, toLocalFile } from './nimUtils';
+import { prepareConfig, getProjectFileInfo, isProjectMode, getBinPath, ProjectFileInfo, toLocalFile } from './nimUtils';
 
 class NimSuggestProcessDescription {
     process?: cp.ChildProcess;
@@ -147,7 +147,7 @@ export function isNimSuggestVersion(version: string): boolean {
 export function initNimSuggest() {
     prepareConfig();
     // let check nimsuggest related nim executable
-    let nimSuggestNewPath = path.resolve(path.dirname(getNimExecPath()), correctBinname('nimsuggest'));
+    let nimSuggestNewPath = path.resolve(getBinPath('nimsuggest'));
     if (fs.existsSync(nimSuggestNewPath)) {
         _nimSuggestPath = nimSuggestNewPath;
         let versionOutput = cp.spawnSync(getNimSuggestPath(), ['--version'], { cwd: vscode.workspace.rootPath }).output.toString();


### PR DESCRIPTION
There are some changes to `inim` (0.5.0) which makes it possible to turn off auto-indent (`--noAutoIndent`). This makes it behave more like `ipython` when sending text to it, ie. no added spaces to lines.  It enables basic REPL-driven development where you send selected lines to the terminal for evaluation.

Specifically, this PR:
- Select terminal you want to run, `nim secret` or `inim`
- Maintain the indentation of lines sent to the terminal. For example, you have a few empty lines in the middle of a code block, these will be padded with spaces to not trigger compilation (single empty lines signal end of code block `inim` and `ipython` and will run that code, for example.
- Refactor file ending lookup of executables on Windows. It assumed only `.exe` before, now supports `.exe, .cmd or empty`, in that order. (`inim` uses a `.cmd` to bootstrap the `.exe` on Windows.)
- `inim` required to be in `PATH`, usually `~/.nimble/bin`