### PR TITLE
Fix html scope to text.html.basic

### DIFF
--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -516,7 +516,7 @@
               "name": "keyword.operator.nim"
             },
             {
-              "include": "text.html"
+              "include": "text.html.basic"
             }
           ]
         }


### PR DESCRIPTION
The correct scope for html is `text.html.basic`

This seems to be a common issue with grammars originally imported from textmate but in vscode the correct scope is `text.html.basic`

References: https://github.com/microsoft/vscode/blob/ad407028575a77ea387eb7cc219b323dc017b686/extensions/shellscript/syntaxes/shell-unix-bash.tmLanguage.json#L454
https://github.com/microsoft/vscode/blob/ad407028575a77ea387eb7cc219b323dc017b686/extensions/handlebars/syntaxes/Handlebars.tmLanguage.json#L42
https://github.com/microsoft/vscode/blob/ad407028575a77ea387eb7cc219b323dc017b686/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json#L125

No need to change contentName since it's relative to this grammar only.