### PR TITLE
make dirty files unique as nimsuggest expects (fixes #180)

### DIFF
--- a/src/nimUtils.ts
+++ b/src/nimUtils.ts
@@ -10,6 +10,7 @@ import path = require('path');
 import os = require('os');
 import cp = require('child_process');
 import vscode = require('vscode');
+const mkdirp = require('mkdirp');
 
 export interface ProjectFileInfo {
     wsFolder: vscode.WorkspaceFolder;
@@ -160,8 +161,14 @@ export function getProjectFileInfo(filename: string): ProjectFileInfo {
  * Returns temporary file path of edited document.
  */
 export function getDirtyFile(document: vscode.TextDocument): string {
-    var dirtyFilePath = path.normalize(path.join(os.tmpdir(), 'vscodenimdirty.nim'));
+    let projectInfo = getProjectFileInfo(document.fileName);
+    let projectFilePath = document.fileName.substring(projectInfo.wsFolder.uri.path.length);
+    var dirtyFilePath = path.normalize(path.join(os.tmpdir(), projectInfo.wsFolder.name, projectFilePath));
+    if (fs.existsSync(dirtyFilePath) === false) {
+        mkdirp.sync(path.dirname(dirtyFilePath));
+    }
     fs.writeFileSync(dirtyFilePath, document.getText());
+
     return dirtyFilePath;
 }
 


### PR DESCRIPTION
Fixes #180

Description:
`include`s appeared to not be processed correctly. This is because nimsuggest (and the nim compiler) assumes that all dirty files are unique. However, nimsuggest was using 1 shared dirty file. This fix creates a directory structure in the same `tmp` dir mirroring the project structure. EDIT: I could've used hashes for everything to make them unique, but decided to keep human-readable naming as much as possible so only used a hash postfix for the root dir, in case anything needs introspection later on or for debugging.

Old tmp Structure:
`/tmp/vscodenimdirty.nim`

New tmp Structure:
`/tmp/<project_dir_name>-<unique_number>/path/to/file/in/project`


Old Behavior:
MWE in #180 shows autocompletion stops working when switching files

New Behavior:
autocompletion now works despite switching files


~~Possible issues:
Should append a unique ID for the <project_dir_name>, otherwise multiple projects might end up clobbering each other. 
For example, 2 projects with 1 clobbering file.
ProjectA/main.nim
ProjectA/moduleXYZ.nim
another/ProjectA/main.nim
another/ProjectA/moduleABC.nim
This would clobber in tmp as follows: /tmp/ProjectA/main.nim
I avoided the complete system path because some systems get cranky with long paths. Thoughts?~~
Fixed; see commit.
